### PR TITLE
zeroRk support in docker and macOS

### DIFF
--- a/config/findZerork.cmake
+++ b/config/findZerork.cmake
@@ -22,7 +22,11 @@ if (NOT (DEFINED ENV{ZERORK_DIR}))
             ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
             RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
             INCLUDES DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
-            )
+    )
+
+
+        # exclude some of the zero rk builds by default that are not needed and causing issues on macOS
+        set_target_properties(zerork_flame_api zerork_flame_api_tester.x zerork_flame_api_mpi zerork_flame_api_tester_mpi.x premixed_steady_flame_solver.x premixed_steady_flame_solver_mpi.x PROPERTIES EXCLUDE_FROM_ALL 1 EXCLUDE_FROM_DEFAULT_BUILD 1)
 
         add_library(ZERORK::zerork_cfd_plugin ALIAS zerork_cfd_plugin)
 

--- a/config/findZerork.cmake
+++ b/config/findZerork.cmake
@@ -3,26 +3,25 @@
 if (NOT (DEFINED ENV{ZERORK_DIR}))
     message(STATUS "ZERORK_DIR not set.  Downloading and building zerork...")
 
-
     # CPU build
     if (NOT (DEFINED ENV{ABLATE_GPU}))
         message(STATUS "Builing zerork for CPUs.")
 
         FetchContent_Declare(zerork
-            GIT_REPOSITORY https://github.com/LLNL/zero-rk.git
-            GIT_TAG 3cf4001ed06f05aa6c98b78230e253a89545ddda  #git main branch for both cpu and CUDA
-            )
+                GIT_REPOSITORY https://github.com/LLNL/zero-rk.git
+                GIT_TAG 3cf4001ed06f05aa6c98b78230e253a89545ddda  #git main branch for both cpu and CUDA
+        )
         FetchContent_MakeAvailable(zerork)
 
         set_include_directories_as_system(zerork)
 
         install(TARGETS zerork_cfd_plugin zerork_vectormath ckconverter zerorkutilities zerork spify
-            EXPORT ablateTargets
-            LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
-            ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
-            RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
-            INCLUDES DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
-    )
+                EXPORT ablateTargets
+                LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+                ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+                RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+                INCLUDES DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
+        )
 
 
         # exclude some of the zero rk builds by default that are not needed and causing issues on macOS
@@ -30,7 +29,7 @@ if (NOT (DEFINED ENV{ZERORK_DIR}))
 
         add_library(ZERORK::zerork_cfd_plugin ALIAS zerork_cfd_plugin)
 
-    #Nvidia build
+        #Nvidia build
     elseif ($ENV{ABLATE_GPU} STREQUAL "CUDA")
         message(STATUS "Builing zerork for Nvidia GPUs with cuda.")
 
@@ -43,41 +42,40 @@ if (NOT (DEFINED ENV{ZERORK_DIR}))
         set_include_directories_as_system(zerork)
 
         install(TARGETS zerork_cfd_plugin_gpu zerork_cfd_plugin ckconverter zerork_vectormath zerorkutilities zerork zerork_cuda spify
-            EXPORT ablateTargets
-            LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
-            ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
-            RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
-            INCLUDES DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
+                EXPORT ablateTargets
+                LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+                ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+                RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+                INCLUDES DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
         )
 
         add_library(ZERORK::zerork_cfd_plugin ALIAS zerork_cfd_plugin_gpu)
 
-    elseif($ENV{ABLATE_GPU} STREQUAL "ROCM")
+    elseif ($ENV{ABLATE_GPU} STREQUAL "ROCM")
         message(STATUS "Builing zerork for AMD GPUs and hip.")
 
         FetchContent_Declare(zerork
-            GIT_REPOSITORY https://github.com/LLNL/zero-rk.git
-            GIT_TAG af50489b8ac6a24b025cf49f6e16399bdb5a8342  #points to zerork hip branch
-            )
+                GIT_REPOSITORY https://github.com/LLNL/zero-rk.git
+                GIT_TAG af50489b8ac6a24b025cf49f6e16399bdb5a8342  #points to zerork hip branch
+        )
         FetchContent_MakeAvailable(zerork)
 
         set_include_directories_as_system(zerork)
 
         install(TARGETS zerork_cfd_plugin_gpu zerork_cfd_plugin ckconverter zerork_vectormath zerorkutilities zerork zerork_cuda spify
-            EXPORT ablateTargets
-            LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
-            ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
-            RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
-            INCLUDES DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
-            )
+                EXPORT ablateTargets
+                LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+                ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+                RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+                INCLUDES DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
+        )
 
         add_library(ZERORK::zerork_cfd_plugin ALIAS zerork_cfd_plugin_gpu)
 
-    endif()
+    endif ()
 
 elseif (DEFINED ENV{ZERORK_DIR})
     message(STATUS "Found ZERORK_DIR, using prebuilt zerork")
-
 
     add_library(zerork_cfd_plugin INTERFACE IMPORTED GLOBAL)
     target_include_directories(zerork_cfd_plugin INTERFACE "$ENV{ZERORK_DIR}/include")

--- a/config/petscCompilers.cmake
+++ b/config/petscCompilers.cmake
@@ -46,6 +46,22 @@ if (NOT DEFINED CMAKE_CXX_COMPILER)
     message(STATUS "Using found PETSc c++ Compiler/Flags: ${PETSC_CXX_COMPILER} ${PETSC_FLAGS_OUT}\n")
 endif ()
 
+
+# Check if a Fortran compiler is explicitly stated
+if (NOT DEFINED CMAKE_Fortran_COMPILER)
+    # Set the compilers based upon the PETSc package
+    pkg_get_variable(PETSC_Fortran_COMPILER PETSc fcompiler)
+    set(CMAKE_Fortran_COMPILER ${PETSC_Fortran_COMPILER})
+
+    pkg_get_variable(PETSC_Fortran_FLAGS PETSc fflags_extra)
+    configure_flags("${PETSC_Fortran_FLAGS}" PETSC_FLAGS_OUT)
+
+    set(CMAKE_Fortran_FLAGS_INIT ${PETSC_FLAGS_OUT})
+
+    message(STATUS "Using found PETSc Fortran Compiler/Flags: ${CMAKE_Fortran_COMPILER} ${PETSC_FLAGS_OUT}\n")
+endif ()
+
+
 # Check if a CUDA compiler is explicitly stated
 if (NOT DEFINED CMAKE_CUDA_COMPILER)
     # Set the compilers based upon the PETSc package


### PR DESCRIPTION
I made some changes to the build directions for macOS and the docker image.  To get either to work we need to use the an old superlu_dist that matches zero_rk requirements.  Your PR will still not pass the tests because you change the EOS interface and need to update ChemTab eos when tensor flow is enabled. 